### PR TITLE
feat: add MBID search to cover art drawer

### DIFF
--- a/fetch_cover_art.py
+++ b/fetch_cover_art.py
@@ -93,6 +93,35 @@ def fetch_release_info(mbid: str) -> tuple[str, str]:
     return "".join(artist_parts), album
 
 
+def fetch_release_metadata(mbid: str) -> dict:
+    """Return extended release metadata from MusicBrainz.
+
+    Returns a dict with keys: artist, album, year, label.
+    Raises FetchError on failure.
+    """
+    data = get(f"{MB_BASE}/{mbid}?fmt=json&inc=artist-credits+labels")
+    album = data.get("title", "")
+    credits = data.get("artist-credit", [])
+    artist_parts = []
+    for credit in credits:
+        if isinstance(credit, dict) and "artist" in credit:
+            artist_parts.append(credit["artist"]["name"])
+            if credit.get("joinphrase"):
+                artist_parts.append(credit["joinphrase"])
+    artist = "".join(artist_parts)
+
+    date = data.get("date", "")
+    year = date[:4] if date else None
+
+    label = None
+    label_infos = data.get("label-info", [])
+    if label_infos:
+        li = label_infos[0]
+        label = (li.get("label") or {}).get("name")
+
+    return {"artist": artist, "album": album, "year": year, "label": label}
+
+
 def fetch_cover_art_listing(mbid: str) -> dict:
     return get(f"{CAA_BASE}/{mbid}")
 

--- a/server.py
+++ b/server.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import struct
 import threading
 import time
@@ -22,6 +23,7 @@ from fetch_cover_art import (
     read_mbid_from_file,
     first_music_file,
     fetch_release_info,
+    fetch_release_metadata,
     fetch_cover_art_listing,
     fetch_bytes,
     ext_from_url,
@@ -394,21 +396,21 @@ def _search_discogs(artist: str, album: str) -> dict:
     return source
 
 
-def fetch_sources(album: dict) -> list[dict]:
+def fetch_sources(album: dict, *, artist: str = "", album_name: str = "") -> list[dict]:
     """Query all sources in parallel, probe images, and detect duplicates."""
     mbid = album.get("mbid")
-    artist, album_name = "", ""
 
-    # Try to get artist/album from MusicBrainz first
-    if mbid:
-        try:
-            artist, album_name = _rate_limited_mb(fetch_release_info, mbid)
-        except FetchError:
-            pass
-
-    # Fallback: parse from directory name
     if not artist and not album_name:
-        artist, album_name = _parse_artist_album(album["name"])
+        # Try to get artist/album from MusicBrainz first
+        if mbid:
+            try:
+                artist, album_name = _rate_limited_mb(fetch_release_info, mbid)
+            except FetchError:
+                pass
+
+        # Fallback: parse from directory name
+        if not artist and not album_name:
+            artist, album_name = _parse_artist_album(album["name"])
 
     sources = []
     with ThreadPoolExecutor(max_workers=3) as pool:
@@ -452,6 +454,11 @@ def fetch_sources(album: dict) -> list[dict]:
 # Routes
 # ---------------------------------------------------------------------------
 
+_UUID_RE = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+    re.IGNORECASE,
+)
+
 @app.route("/")
 def index():
     return app.send_static_file("index.html")
@@ -493,6 +500,26 @@ def api_album_sources(album_id):
         abort(404)
     sources = fetch_sources(album)
     return jsonify({"sources": sources})
+
+
+@app.route("/api/mbid/<mbid>/sources")
+def api_mbid_sources(mbid):
+    if not _UUID_RE.fullmatch(mbid):
+        return jsonify({"error": "Invalid MBID format"}), 400
+    try:
+        release = _rate_limited_mb(fetch_release_metadata, mbid)
+    except FetchError:
+        return jsonify({"error": "Release not found in MusicBrainz."}), 404
+    synthetic_album = {
+        "id": mbid,
+        "name": f"{release['artist']} - {release['album']}",
+        "mbid": mbid,
+        "cover_size_kb": 0,
+        "cover_width": 0,
+        "cover_height": 0,
+    }
+    sources = fetch_sources(synthetic_album, artist=release["artist"], album_name=release["album"])
+    return jsonify({"sources": sources, "release": release})
 
 
 @app.route("/api/albums/<album_id>/replace", methods=["POST"])

--- a/static/app.js
+++ b/static/app.js
@@ -4,24 +4,27 @@ let activeAlbumId = null;
 let sourcesAbort = null;  // AbortController for in-flight source requests
 
 /* ── DOM refs ─────────────────────────────────────────────────── */
-const grid         = document.getElementById("album-grid");
-const searchInput  = document.getElementById("search-input");
-const filterSelect = document.getElementById("filter-select");
-const rescanBtn    = document.getElementById("rescan-btn");
-const drawer       = document.getElementById("drawer");
-const overlay      = document.getElementById("drawer-overlay");
-const drawerTitle  = document.getElementById("drawer-title");
-const drawerClose  = document.getElementById("drawer-close");
-const currentCover = document.getElementById("current-cover");
-const currentMeta  = document.getElementById("current-meta");
-const noCoverMsg   = document.getElementById("no-cover-msg");
-const sourcesLoad  = document.getElementById("sources-loading");
-const sourcesList  = document.getElementById("sources-list");
-const noSourcesMsg = document.getElementById("no-sources-msg");
-const albumCount   = document.getElementById("album-count");
-const mediaList    = document.getElementById("media-list");
-const noMediaMsg   = document.getElementById("no-media-msg");
-const mediaCount   = document.getElementById("media-count");
+const grid            = document.getElementById("album-grid");
+const searchInput     = document.getElementById("search-input");
+const filterSelect    = document.getElementById("filter-select");
+const rescanBtn       = document.getElementById("rescan-btn");
+const drawer          = document.getElementById("drawer");
+const overlay         = document.getElementById("drawer-overlay");
+const drawerTitle     = document.getElementById("drawer-title");
+const drawerClose     = document.getElementById("drawer-close");
+const currentCover    = document.getElementById("current-cover");
+const currentMeta     = document.getElementById("current-meta");
+const noCoverMsg      = document.getElementById("no-cover-msg");
+const sourcesLoad     = document.getElementById("sources-loading");
+const sourcesList     = document.getElementById("sources-list");
+const noSourcesMsg    = document.getElementById("no-sources-msg");
+const albumCount      = document.getElementById("album-count");
+const mediaList       = document.getElementById("media-list");
+const noMediaMsg      = document.getElementById("no-media-msg");
+const mediaCount      = document.getElementById("media-count");
+const mbidInput       = document.getElementById("mbid-input");
+const mbidSearchBtn   = document.getElementById("mbid-search-btn");
+const mbidReleaseInfo = document.getElementById("mbid-release-info");
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 function qualityClass(sizeKb) {
@@ -135,6 +138,12 @@ function openDrawer(albumId) {
     noCoverMsg.classList.remove("hidden");
   }
 
+  // Reset MBID search
+  mbidInput.value = "";
+  mbidInput.setCustomValidity("");
+  mbidReleaseInfo.classList.add("hidden");
+  mbidReleaseInfo.textContent = "";
+
   // Reset sources
   sourcesList.innerHTML = "";
   noSourcesMsg.classList.add("hidden");
@@ -170,8 +179,51 @@ function closeDrawer() {
   renderGrid();
 }
 
+/* ── Sources ──────────────────────────────────────────────────── */
+function renderSourcesList(sources, albumId) {
+  if (!sources || sources.length === 0) {
+    noSourcesMsg.classList.remove("hidden");
+    return;
+  }
+  sourcesList.innerHTML = sources.map(src => {
+    const images = src.images.map(img => {
+      const res = img.width && img.height ? `${img.width}\u00d7${img.height}` : "";
+      const size = img.size_kb > 0 ? formatSize(img.size_kb) : "";
+      const metaParts = [res, size].filter(Boolean).join(" \u00b7 ");
+      const matchBadge = img.match === "current"
+        ? `<span class="match-badge">Current</span>`
+        : "";
+      const isCurrent = img.match === "current";
+      return `
+      <div class="source-image${isCurrent ? ' is-current' : ''}">
+        <img src="${esc(img.thumbnail_url)}" alt="thumbnail" loading="lazy">
+        <div class="source-image-info">
+          <div class="detail">${esc(img.source_detail || img.label)}${matchBadge}</div>
+          <div class="sub-detail">${esc(img.type)}${metaParts ? ' \u00b7 ' + esc(metaParts) : ''}</div>
+        </div>
+        <div class="btn-group">
+          <button class="use-btn" data-album="${albumId}" data-url="${esc(img.url)}">Use</button>
+          <button class="save-btn" data-album="${albumId}" data-url="${esc(img.url)}" data-type="${esc(img.type)}">Save</button>
+        </div>
+      </div>`;
+    }).join("");
+
+    return `
+      <div class="source-group">
+        <div class="source-group-header">${esc(src.source)}</div>
+        ${images}
+      </div>
+    `;
+  }).join("");
+}
+
+function renderReleaseInfo(release) {
+  const parts = [release.artist, release.album, release.year, release.label].filter(Boolean);
+  mbidReleaseInfo.textContent = parts.join(" \u00b7 ");
+  mbidReleaseInfo.classList.remove("hidden");
+}
+
 async function loadSources(albumId) {
-  // Cancel any previous request
   if (sourcesAbort) sourcesAbort.abort();
   sourcesAbort = new AbortController();
 
@@ -179,43 +231,38 @@ async function loadSources(albumId) {
     const resp = await fetch(`/api/albums/${albumId}/sources`, { signal: sourcesAbort.signal });
     const data = await resp.json();
     sourcesLoad.classList.add("hidden");
+    renderSourcesList(data.sources, albumId);
+  } catch (e) {
+    if (e.name !== "AbortError") {
+      sourcesLoad.classList.add("hidden");
+      noSourcesMsg.textContent = "Failed to load sources.";
+      noSourcesMsg.classList.remove("hidden");
+    }
+  }
+}
 
-    if (!data.sources || data.sources.length === 0) {
+async function loadSourcesByMbid(albumId, mbid) {
+  if (sourcesAbort) sourcesAbort.abort();
+  sourcesAbort = new AbortController();
+
+  sourcesList.innerHTML = "";
+  noSourcesMsg.classList.add("hidden");
+  mbidReleaseInfo.classList.add("hidden");
+  sourcesLoad.classList.remove("hidden");
+
+  try {
+    const resp = await fetch(`/api/mbid/${encodeURIComponent(mbid)}/sources`, { signal: sourcesAbort.signal });
+    const data = await resp.json();
+    sourcesLoad.classList.add("hidden");
+
+    if (!resp.ok) {
+      noSourcesMsg.textContent = data.error || "Release not found.";
       noSourcesMsg.classList.remove("hidden");
       return;
     }
 
-    sourcesList.innerHTML = data.sources.map(src => {
-      const images = src.images.map(img => {
-        const res = img.width && img.height ? `${img.width}\u00d7${img.height}` : "";
-        const size = img.size_kb > 0 ? formatSize(img.size_kb) : "";
-        const metaParts = [res, size].filter(Boolean).join(" \u00b7 ");
-        const matchBadge = img.match === "current"
-          ? `<span class="match-badge">Current</span>`
-          : "";
-        const isCurrent = img.match === "current";
-        return `
-        <div class="source-image${isCurrent ? ' is-current' : ''}">
-          <img src="${esc(img.thumbnail_url)}" alt="thumbnail" loading="lazy">
-          <div class="source-image-info">
-            <div class="detail">${esc(img.source_detail || img.label)}${matchBadge}</div>
-            <div class="sub-detail">${esc(img.type)}${metaParts ? ' \u00b7 ' + esc(metaParts) : ''}</div>
-          </div>
-          <div class="btn-group">
-            <button class="use-btn" data-album="${albumId}" data-url="${esc(img.url)}">Use</button>
-            <button class="save-btn" data-album="${albumId}" data-url="${esc(img.url)}" data-type="${esc(img.type)}">Save</button>
-          </div>
-        </div>`;
-      }).join("");
-
-      return `
-        <div class="source-group">
-          <div class="source-group-header">${esc(src.source)}</div>
-          ${images}
-        </div>
-      `;
-    }).join("");
-
+    if (data.release) renderReleaseInfo(data.release);
+    renderSourcesList(data.sources, albumId);
   } catch (e) {
     if (e.name !== "AbortError") {
       sourcesLoad.classList.add("hidden");
@@ -389,6 +436,25 @@ sourcesList.addEventListener("click", (e) => {
 
 searchInput.addEventListener("input", renderGrid);
 filterSelect.addEventListener("change", renderGrid);
+
+const _UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function triggerMbidSearch() {
+  const mbid = mbidInput.value.trim();
+  if (!_UUID_RE.test(mbid)) {
+    mbidInput.setCustomValidity("Enter a valid MusicBrainz Release UUID");
+    mbidInput.reportValidity();
+    return;
+  }
+  mbidInput.setCustomValidity("");
+  loadSourcesByMbid(activeAlbumId, mbid);
+}
+
+mbidSearchBtn.addEventListener("click", triggerMbidSearch);
+mbidInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") triggerMbidSearch();
+});
+mbidInput.addEventListener("input", () => mbidInput.setCustomValidity(""));
 
 rescanBtn.addEventListener("click", async () => {
   rescanBtn.disabled = true;

--- a/static/index.html
+++ b/static/index.html
@@ -51,6 +51,11 @@
 
     <div id="drawer-sources">
       <h3>Find Higher Resolution</h3>
+      <div id="mbid-search">
+        <input type="text" id="mbid-input" placeholder="Search by Release MBID (UUID)..." autocomplete="off" spellcheck="false">
+        <button id="mbid-search-btn">Search</button>
+      </div>
+      <div id="mbid-release-info" class="hidden"></div>
       <div id="sources-loading" class="hidden">
         <div class="spinner"></div>
         <span>Searching sources...</span>

--- a/static/style.css
+++ b/static/style.css
@@ -462,6 +462,54 @@ body.drawer-open #album-grid { padding-right: calc(var(--drawer-w) + 24px); }
   vertical-align: middle;
 }
 
+/* ── MBID search ──────────────────────────────────────────────── */
+#mbid-search {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+#mbid-input {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 0.8rem;
+  font-family: monospace;
+  outline: none;
+}
+
+#mbid-input:focus { border-color: var(--accent); }
+
+#mbid-search-btn {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+#mbid-search-btn:hover { background: var(--bg-hover); }
+
+#mbid-release-info {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  padding: 6px 10px;
+  background: var(--bg-input);
+  border-radius: var(--radius);
+  margin-bottom: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ── Media assets ─────────────────────────────────────────────── */
 #drawer-media {
   padding: 16px 20px;


### PR DESCRIPTION
## Summary

- Adds a Release MBID search field to the **Find Higher Resolution** section of the drawer
- User can paste any MusicBrainz Release MBID (e.g. a different pressing with better art) and search CAA, iTunes, and Discogs for its cover images
- A release info strip displays artist · album · year · label for the searched release
- Use/Save buttons always apply to the **locally open album**, not the searched release
- Client-side UUID format validation with native browser validation popup
- Enter key triggers the search

## How it works

1. New `fetch_release_metadata(mbid)` in `fetch_cover_art.py` hits the MB API with `inc=artist-credits+labels` and returns `{artist, album, year, label}`
2. New `GET /api/mbid/<mbid>/sources` endpoint validates the UUID, fetches release metadata, builds a synthetic album dict, and calls the existing `fetch_sources` — returning `{sources, release}`
3. `fetch_sources` extended with keyword-only `artist`/`album_name` params so the route can pass pre-fetched metadata and skip a redundant MB API call

## Test plan

- [ ] Open an album in the drawer
- [ ] Paste a valid MusicBrainz Release MBID (e.g. from `https://musicbrainz.org/release/<mbid>`) and click Search or press Enter
- [ ] Verify the release info strip shows artist · album · year · label
- [ ] Verify cover art sources load from CAA/iTunes/Discogs
- [ ] Click **Use** on a result and confirm it updates the locally open album's cover
- [ ] Click **Save** and confirm it saves to the local album's `.media/` folder
- [ ] Enter an invalid UUID and verify the browser shows a validation error without making a network request
- [ ] Enter a UUID that doesn't exist in MusicBrainz and verify "Release not found in MusicBrainz." is shown
- [ ] Open a different album — verify the MBID input is cleared