### PR TITLE
feat: add lightbox full-size preview for drawer images

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -25,6 +25,8 @@ const mediaCount      = document.getElementById("media-count");
 const mbidInput       = document.getElementById("mbid-input");
 const mbidSearchBtn   = document.getElementById("mbid-search-btn");
 const mbidReleaseInfo = document.getElementById("mbid-release-info");
+const lightbox        = document.getElementById("lightbox");
+const lightboxImg     = document.getElementById("lightbox-img");
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 function qualityClass(sizeKb) {
@@ -196,7 +198,7 @@ function renderSourcesList(sources, albumId) {
       const isCurrent = img.match === "current";
       return `
       <div class="source-image${isCurrent ? ' is-current' : ''}">
-        <img src="${esc(img.thumbnail_url)}" alt="thumbnail" loading="lazy">
+        <img src="${esc(img.thumbnail_url)}" data-fullurl="${esc(img.url)}" alt="thumbnail" loading="lazy">
         <div class="source-image-info">
           <div class="detail">${esc(img.source_detail || img.label)}${matchBadge}</div>
           <div class="sub-detail">${esc(img.type)}${metaParts ? ' \u00b7 ' + esc(metaParts) : ''}</div>
@@ -419,7 +421,10 @@ drawerClose.addEventListener("click", closeDrawer);
 overlay.addEventListener("click", closeDrawer);
 
 document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") closeDrawer();
+  if (e.key === "Escape") {
+    if (!lightbox.classList.contains("hidden")) closeLightbox();
+    else closeDrawer();
+  }
 });
 
 sourcesList.addEventListener("click", (e) => {
@@ -466,6 +471,33 @@ rescanBtn.addEventListener("click", async () => {
     rescanBtn.disabled = false;
     rescanBtn.textContent = "Rescan";
   }
+});
+
+/* ── Lightbox ─────────────────────────────────────────────────── */
+function openLightbox(url) {
+  lightboxImg.src = url;
+  lightbox.classList.remove("hidden");
+}
+
+function closeLightbox() {
+  lightbox.classList.add("hidden");
+  lightboxImg.src = "";
+}
+
+currentCover.addEventListener("click", () => {
+  if (!currentCover.classList.contains("hidden")) openLightbox(currentCover.src);
+});
+
+lightbox.addEventListener("click", closeLightbox);
+
+mediaList.addEventListener("click", (e) => {
+  const img = e.target.closest(".media-file img");
+  if (img) openLightbox(img.src);
+});
+
+sourcesList.addEventListener("click", (e) => {
+  const img = e.target.closest(".source-image img");
+  if (img) openLightbox(img.dataset.fullurl);
 });
 
 /* ── Init ─────────────────────────────────────────────────────── */

--- a/static/index.html
+++ b/static/index.html
@@ -65,6 +65,10 @@
     </div>
   </aside>
 
+  <div id="lightbox" class="hidden">
+    <img id="lightbox-img" alt="Full size preview">
+  </div>
+
   <script src="/static/app.js"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -569,4 +569,28 @@ body.drawer-open #album-grid { padding-right: calc(var(--drawer-w) + 24px); }
   #search-input { width: 140px; }
 }
 
+/* ── Lightbox ─────────────────────────────────────────────────── */
+#lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  background: rgba(0, 0, 0, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: zoom-out;
+}
+
+#lightbox img {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: var(--radius);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.8);
+}
+
+.current-cover-wrap img { cursor: zoom-in; }
+.media-file img          { cursor: zoom-in; }
+.source-image img        { cursor: zoom-in; }
+
 .hidden { display: none !important; }


### PR DESCRIPTION
## Summary

- Clicking any image in the drawer (current cover, media assets, source thumbnails) opens a full-size lightbox overlay
- Source thumbnails open the full-resolution external URL directly
- Click anywhere on the overlay or press Escape to dismiss

## Changes

- `static/index.html` — added `#lightbox` overlay element
- `static/style.css` — lightbox styles + `zoom-in` cursor on all clickable thumbnails
- `static/app.js` — `openLightbox`/`closeLightbox` functions, click handlers for all three image types, Escape key closes lightbox before drawer

## Test plan

- [ ] Open an album drawer and click the current cover → full-size image appears
- [ ] Click a media asset thumbnail → full-size image appears
- [ ] Click a source candidate thumbnail → full-size external image appears
- [ ] Click the overlay background → lightbox closes
- [ ] Press Escape while lightbox is open → lightbox closes (drawer stays open)
- [ ] Press Escape with no lightbox → drawer closes as before