### PR TITLE
feat: add delete button with confirmation modal for media assets

### DIFF
--- a/server.py
+++ b/server.py
@@ -702,6 +702,25 @@ def api_album_save_media(album_id):
     })
 
 
+@app.route("/api/albums/<album_id>/media/<path:filename>", methods=["DELETE"])
+def api_album_delete_media(album_id, filename):
+    """Delete a file from the album's .media/ directory."""
+    with _albums_lock:
+        album = albums.get(album_id)
+    if not album:
+        abort(404)
+    media_dir = (album["path"] / ".media").resolve()
+    media_path = (album["path"] / ".media" / filename).resolve()
+    try:
+        media_path.relative_to(media_dir)
+    except ValueError:
+        abort(403)
+    if not media_path.exists() or not media_path.is_file():
+        abort(404)
+    media_path.unlink()
+    return jsonify({"ok": True})
+
+
 @app.route("/api/rescan", methods=["POST"])
 def api_rescan():
     if MUSIC_DIR is None:

--- a/static/app.js
+++ b/static/app.js
@@ -27,6 +27,10 @@ const mbidSearchBtn   = document.getElementById("mbid-search-btn");
 const mbidReleaseInfo = document.getElementById("mbid-release-info");
 const lightbox        = document.getElementById("lightbox");
 const lightboxImg     = document.getElementById("lightbox-img");
+const confirmModal    = document.getElementById("confirm-modal");
+const confirmMessage  = document.getElementById("confirm-message");
+const confirmCancel   = document.getElementById("confirm-cancel");
+const confirmOk       = document.getElementById("confirm-ok");
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 function qualityClass(sizeKb) {
@@ -350,22 +354,81 @@ async function loadMedia(albumId) {
     }
     noMediaMsg.classList.add("hidden");
     mediaCount.textContent = files.length;
-    mediaList.innerHTML = files.map(f => {
+
+    mediaList.innerHTML = "";
+    for (const f of files) {
       const res = f.width && f.height ? formatRes(f.width, f.height) : "";
       const size = f.size_kb > 0 ? formatSize(f.size_kb) : "";
       const meta = [res, size].filter(Boolean).join(" \u00b7 ");
-      return `
-        <div class="media-file">
-          <img src="/api/albums/${albumId}/media/${esc(f.filename)}" alt="${esc(f.filename)}" loading="lazy">
-          <div class="source-image-info">
-            <div class="detail">${esc(f.filename)}</div>
-            <div class="sub-detail">${meta}</div>
-          </div>
-        </div>`;
-    }).join("");
+
+      const row = document.createElement("div");
+      row.className = "media-file";
+
+      const img = document.createElement("img");
+      img.src = `/api/albums/${albumId}/media/${encodeURIComponent(f.filename)}`;
+      img.alt = f.filename;
+      img.loading = "lazy";
+
+      const info = document.createElement("div");
+      info.className = "source-image-info";
+      const detail = document.createElement("div");
+      detail.className = "detail";
+      detail.textContent = f.filename;
+      const subDetail = document.createElement("div");
+      subDetail.className = "sub-detail";
+      subDetail.textContent = meta;
+      info.append(detail, subDetail);
+
+      const delBtn = document.createElement("button");
+      delBtn.className = "delete-btn";
+      delBtn.textContent = "Delete";
+      delBtn.dataset.album = albumId;
+      delBtn.dataset.filename = f.filename;
+
+      row.append(img, info, delBtn);
+      mediaList.appendChild(row);
+    }
   } catch (e) {
     noMediaMsg.textContent = "Failed to load media.";
     noMediaMsg.classList.remove("hidden");
+  }
+}
+
+/* ── Confirm modal ────────────────────────────────────────────── */
+let _confirmResolve = null;
+
+function showConfirm(message) {
+  confirmMessage.textContent = message;
+  confirmModal.classList.remove("hidden");
+  return new Promise(resolve => { _confirmResolve = resolve; });
+}
+
+confirmCancel.addEventListener("click", () => {
+  confirmModal.classList.add("hidden");
+  if (_confirmResolve) { _confirmResolve(false); _confirmResolve = null; }
+});
+
+confirmOk.addEventListener("click", () => {
+  confirmModal.classList.add("hidden");
+  if (_confirmResolve) { _confirmResolve(true); _confirmResolve = null; }
+});
+
+async function deleteMediaFile(btn, albumId, filename) {
+  const confirmed = await showConfirm(`Delete "${filename}"? This cannot be undone.`);
+  if (!confirmed) return;
+
+  btn.disabled = true;
+  try {
+    const resp = await fetch(`/api/albums/${albumId}/media/${encodeURIComponent(filename)}`, {
+      method: "DELETE",
+    });
+    if (resp.ok) {
+      loadMedia(albumId);
+    } else {
+      btn.disabled = false;
+    }
+  } catch (e) {
+    btn.disabled = false;
   }
 }
 
@@ -491,6 +554,11 @@ currentCover.addEventListener("click", () => {
 lightbox.addEventListener("click", closeLightbox);
 
 mediaList.addEventListener("click", (e) => {
+  const delBtn = e.target.closest(".delete-btn");
+  if (delBtn && !delBtn.disabled) {
+    deleteMediaFile(delBtn, delBtn.dataset.album, delBtn.dataset.filename);
+    return;
+  }
   const img = e.target.closest(".media-file img");
   if (img) openLightbox(img.src);
 });

--- a/static/index.html
+++ b/static/index.html
@@ -65,6 +65,16 @@
     </div>
   </aside>
 
+  <div id="confirm-modal" class="hidden">
+    <div class="confirm-dialog">
+      <p id="confirm-message">Are you sure?</p>
+      <div class="confirm-actions">
+        <button id="confirm-cancel">Cancel</button>
+        <button id="confirm-ok" class="danger">Delete</button>
+      </div>
+    </div>
+  </div>
+
   <div id="lightbox" class="hidden">
     <img id="lightbox-img" alt="Full size preview">
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -569,6 +569,81 @@ body.drawer-open #album-grid { padding-right: calc(var(--drawer-w) + 24px); }
   #search-input { width: 140px; }
 }
 
+/* ── Confirmation Modal ───────────────────────────────────────── */
+#confirm-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-dialog {
+  background: var(--bg-drawer);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  min-width: 260px;
+  max-width: 360px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.confirm-dialog p {
+  font-size: 0.9rem;
+  margin-bottom: 20px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-actions button {
+  padding: 6px 16px;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text);
+  transition: background 0.15s;
+}
+
+.confirm-actions button:hover { background: var(--bg-hover); }
+
+.confirm-actions button.danger {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.confirm-actions button.danger:hover {
+  background: var(--red);
+  color: #000;
+}
+
+.delete-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--red);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--red);
+  font-size: 0.72rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.delete-btn:hover {
+  background: var(--red);
+  color: #000;
+}
+
 /* ── Lightbox ─────────────────────────────────────────────────── */
 #lightbox {
   position: fixed;


### PR DESCRIPTION
## Summary

- Each item in the Media Assets section of the drawer now has a **Delete** button
- Clicking Delete opens a confirmation modal asking the user to confirm before permanently removing the file
- New `DELETE /api/albums/<id>/media/<filename>` endpoint on the server with path-traversal protection

## Test plan

- [ ] Open an album drawer that has `.media/` files
- [ ] Verify each media item shows a red **Delete** button
- [ ] Click Delete — confirm the modal appears with the filename and a Cancel / Delete option
- [ ] Click **Cancel** — confirm the file is NOT deleted and the list is unchanged
- [ ] Click **Delete** again, then confirm **Delete** — confirm the file disappears from the list
- [ ] Verify the file is actually removed from disk
- [ ] Verify clicking the thumbnail still opens the lightbox (delete button click doesn't bleed through)