### PR TITLE
feat: display MB ID from music file tags in album drawer

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -25,6 +25,7 @@ const mediaCount      = document.getElementById("media-count");
 const mbidInput       = document.getElementById("mbid-input");
 const mbidSearchBtn   = document.getElementById("mbid-search-btn");
 const mbidReleaseInfo = document.getElementById("mbid-release-info");
+const currentMbid     = document.getElementById("current-mbid");
 const lightbox        = document.getElementById("lightbox");
 const lightboxImg     = document.getElementById("lightbox-img");
 const confirmModal    = document.getElementById("confirm-modal");
@@ -144,8 +145,23 @@ function openDrawer(albumId) {
     noCoverMsg.classList.remove("hidden");
   }
 
-  // Reset MBID search
-  mbidInput.value = "";
+  // Show MBID from tags
+  if (album.mbid) {
+    const label = document.createElement("span");
+    label.className = "mbid-label";
+    label.textContent = "MB ID: ";
+    const value = document.createElement("span");
+    value.className = "mbid-value";
+    value.textContent = album.mbid;
+    currentMbid.replaceChildren(label, value);
+    currentMbid.className = "mbid-found";
+  } else {
+    currentMbid.textContent = "No MB ID found in music files";
+    currentMbid.className = "mbid-missing";
+  }
+
+  // Pre-fill MBID search with tag value if available
+  mbidInput.value = album.mbid || "";
   mbidInput.setCustomValidity("");
   mbidReleaseInfo.classList.add("hidden");
   mbidReleaseInfo.textContent = "";

--- a/static/index.html
+++ b/static/index.html
@@ -41,6 +41,7 @@
         <div id="current-meta" class="meta-badges"></div>
       </div>
       <p id="no-cover-msg" class="hidden">No cover art found for this album.</p>
+      <div id="current-mbid"></div>
     </div>
 
     <div id="drawer-media">

--- a/static/style.css
+++ b/static/style.css
@@ -319,6 +319,17 @@ body.drawer-open #album-grid { padding-right: calc(var(--drawer-w) + 24px); }
   padding: 20px;
 }
 
+#current-mbid {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+#current-mbid.mbid-found { color: var(--text-dim); }
+#current-mbid.mbid-found .mbid-label { opacity: 0.7; }
+#current-mbid.mbid-found .mbid-value { font-family: monospace; letter-spacing: 0.02em; }
+#current-mbid.mbid-missing { color: var(--text-dim); font-style: italic; opacity: 0.7; }
+
 /* ── Sources ──────────────────────────────────────────────────── */
 #sources-loading {
   display: flex;


### PR DESCRIPTION
## Summary

- Reads the MB ID already extracted from audio file tags and displays it below the current cover art in the drawer
- If an MB ID is found, it is shown in monospace with a subtle label and pre-filled into the MBID search input (so the more-accurate MBID-based search is used without extra steps)
- If no MB ID is found in the music files, a note — "No MB ID found in music files" — is shown so the user knows they need to enter one manually

## Test plan

- [ ] Open an album that has an MB ID in its audio tags → MB ID should appear below the cover art and be pre-filled in the search box; sources should load using that MBID
- [ ] Open an album with no MB ID in its tags → "No MB ID found in music files" message should appear; search box should be empty
- [ ] Confirm the MBID search field still accepts manual input and works as before
- [ ] Verify the MB ID display is readable and doesn't interfere with the cover image or meta badges