### PR TITLE
feat: sort media assets by size descending in drawer

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -362,7 +362,7 @@ async function loadMedia(albumId) {
   try {
     const resp = await fetch(`/api/albums/${albumId}/media`);
     const data = await resp.json();
-    const files = data.files || [];
+    const files = (data.files || []).sort((a, b) => b.size_kb - a.size_kb);
     if (files.length === 0) {
       noMediaMsg.classList.remove("hidden");
       mediaCount.textContent = "";


### PR DESCRIPTION
## Summary

- Media assets in the drawer are now sorted by file size (largest first) rather than by filename
- Sorting happens client-side after the API response, so no backend changes needed

## Test plan

- [ ] Open an album with multiple files in its `.media/` directory
- [ ] Confirm the largest files appear at the top of the Media Assets list
- [ ] Confirm files of equal size retain a stable relative order