### PR TITLE
feat: add Use button to media assets to swap as cover

### DIFF
--- a/server.py
+++ b/server.py
@@ -721,6 +721,86 @@ def api_album_delete_media(album_id, filename):
     return jsonify({"ok": True})
 
 
+@app.route("/api/albums/<album_id>/use-media", methods=["POST"])
+def api_album_use_media(album_id):
+    """Swap a .media/ file in as the cover, archiving the current cover to .media/."""
+    with _albums_lock:
+        album = albums.get(album_id)
+    if not album:
+        abort(404)
+    data = request.get_json()
+    if not data or "filename" not in data:
+        return jsonify({"error": "Missing 'filename' in request body"}), 400
+
+    album_dir = album["path"]
+    media_dir = album_dir / ".media"
+    media_path = (media_dir / data["filename"]).resolve()
+
+    try:
+        media_path.relative_to(media_dir.resolve())
+    except ValueError:
+        abort(403)
+    if not media_path.exists() or not media_path.is_file():
+        abort(404)
+
+    try:
+        img = Image.open(media_path)
+        img.verify()
+        img = Image.open(media_path)
+        w, h = img.size
+    except Exception:
+        return jsonify({"error": "File is not a valid image"}), 400
+
+    # Archive current cover into .media/ before replacing it
+    current_cover = _find_cover(album_dir)
+    if current_cover:
+        media_dir.mkdir(exist_ok=True)
+        cover_ext = current_cover.suffix
+        counter = 1
+        while True:
+            backup_name = f"Cover-{counter:03d}{cover_ext}"
+            if not (media_dir / backup_name).exists():
+                break
+            counter += 1
+        current_cover.rename(media_dir / backup_name)
+        for old_ext in (".jpg", ".jpeg", ".png", ".webp", ".gif"):
+            thumb = album_dir / f"thumbnail{old_ext}"
+            if thumb.exists():
+                thumb.unlink()
+
+    new_ext = media_path.suffix
+    new_cover = album_dir / f"cover{new_ext}"
+    img_data = media_path.read_bytes()
+    media_path.rename(new_cover)
+
+    size_kb = round(len(img_data) / 1024, 1)
+
+    try:
+        thumb_img = Image.open(new_cover)
+        thumb_img.thumbnail((250, 250), Image.LANCZOS)
+        thumb_path = album_dir / f"thumbnail{new_ext}"
+        if new_ext in (".jpg", ".jpeg"):
+            thumb_img.save(thumb_path, "JPEG", quality=85)
+        else:
+            thumb_img.save(thumb_path)
+    except Exception:
+        pass
+
+    with _albums_lock:
+        albums[album_id]["cover_path"] = new_cover
+        albums[album_id]["has_cover"] = True
+        albums[album_id]["cover_size_kb"] = size_kb
+        albums[album_id]["cover_width"] = w
+        albums[album_id]["cover_height"] = h
+
+    return jsonify({
+        "ok": True,
+        "cover_size_kb": size_kb,
+        "cover_width": w,
+        "cover_height": h,
+    })
+
+
 @app.route("/api/rescan", methods=["POST"])
 def api_rescan():
     if MUSIC_DIR is None:

--- a/static/app.js
+++ b/static/app.js
@@ -395,13 +395,23 @@ async function loadMedia(albumId) {
       subDetail.textContent = meta;
       info.append(detail, subDetail);
 
+      const useBtn = document.createElement("button");
+      useBtn.className = "use-btn";
+      useBtn.textContent = "Use";
+      useBtn.dataset.album = albumId;
+      useBtn.dataset.filename = f.filename;
+
       const delBtn = document.createElement("button");
       delBtn.className = "delete-btn";
       delBtn.textContent = "Delete";
       delBtn.dataset.album = albumId;
       delBtn.dataset.filename = f.filename;
 
-      row.append(img, info, delBtn);
+      const btnGroup = document.createElement("div");
+      btnGroup.className = "btn-group";
+      btnGroup.append(useBtn, delBtn);
+
+      row.append(img, info, btnGroup);
       mediaList.appendChild(row);
     }
   } catch (e) {
@@ -428,6 +438,56 @@ confirmOk.addEventListener("click", () => {
   confirmModal.classList.add("hidden");
   if (_confirmResolve) { _confirmResolve(true); _confirmResolve = null; }
 });
+
+async function useMediaAsCover(btn, albumId, filename) {
+  btn.disabled = true;
+  btn.classList.add("replacing");
+  btn.textContent = "Applying...";
+
+  try {
+    const resp = await fetch(`/api/albums/${albumId}/use-media`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({filename}),
+    });
+    const data = await resp.json();
+
+    if (data.ok) {
+      btn.classList.remove("replacing");
+      btn.classList.add("done");
+      btn.textContent = "Done!";
+
+      const album = allAlbums.find(a => a.id === albumId);
+      if (album) {
+        album.has_cover = true;
+        album.cover_size_kb = data.cover_size_kb;
+        album.cover_width = data.cover_width;
+        album.cover_height = data.cover_height;
+      }
+
+      currentCover.src = `/api/albums/${albumId}/cover?t=${Date.now()}`;
+      currentCover.classList.remove("hidden");
+      noCoverMsg.classList.add("hidden");
+      const q = qualityClass(data.cover_size_kb);
+      currentMeta.innerHTML = `
+        <span class="meta-badge">${formatRes(data.cover_width, data.cover_height)}</span>
+        <span class="meta-badge ${q ? 'quality-' + q : ''}">${formatSize(data.cover_size_kb)}</span>
+      `;
+      currentMeta.classList.remove("hidden");
+
+      renderGrid();
+      loadMedia(albumId);
+    } else {
+      btn.textContent = "Failed";
+      btn.classList.remove("replacing");
+      setTimeout(() => { btn.disabled = false; btn.textContent = "Use"; }, 2000);
+    }
+  } catch (e) {
+    btn.textContent = "Error";
+    btn.classList.remove("replacing");
+    setTimeout(() => { btn.disabled = false; btn.textContent = "Use"; }, 2000);
+  }
+}
 
 async function deleteMediaFile(btn, albumId, filename) {
   const confirmed = await showConfirm(`Delete "${filename}"? This cannot be undone.`);
@@ -570,6 +630,11 @@ currentCover.addEventListener("click", () => {
 lightbox.addEventListener("click", closeLightbox);
 
 mediaList.addEventListener("click", (e) => {
+  const useBtn = e.target.closest(".use-btn");
+  if (useBtn && !useBtn.disabled) {
+    useMediaAsCover(useBtn, useBtn.dataset.album, useBtn.dataset.filename);
+    return;
+  }
   const delBtn = e.target.closest(".delete-btn");
   if (delBtn && !delBtn.disabled) {
     deleteMediaFile(delBtn, delBtn.dataset.album, delBtn.dataset.filename);


### PR DESCRIPTION
## Summary

- Each media asset in the drawer now has a **Use** button alongside Delete
- Clicking Use on a media file promotes it to `cover.*` for that album
- The current cover (if any) is automatically archived into `.media/` as `Cover-001.*` (incrementing to avoid collisions) — nothing is deleted
- A new thumbnail is generated for the new cover
- The drawer's cover image, resolution/size badges, grid quality dot, and media asset list all refresh immediately after the swap
- New backend endpoint: `POST /api/albums/<id>/use-media` with `{"filename": "..."}` body

## Test plan

- [ ] Open an album with files in `.media/` — confirm each row shows a Use button next to Delete
- [ ] Click Use on a media asset → selected file becomes the cover, old cover appears in `.media/` as `Cover-001.*`
- [ ] Swap again → old cover is archived as `Cover-002.*`, confirming no files are overwritten
- [ ] Confirm the cover image, resolution badge, and grid quality dot update without a page reload
- [ ] Confirm path traversal is rejected (403) and missing files return 404
- [ ] Album with no existing cover: clicking Use should set the cover without errors