### PR TITLE
feat: add prev/next navigation to lightbox

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2,6 +2,8 @@
 let allAlbums = [];
 let activeAlbumId = null;
 let sourcesAbort = null;  // AbortController for in-flight source requests
+let lightboxItems = [];
+let lightboxIndex = -1;
 
 /* ── DOM refs ─────────────────────────────────────────────────── */
 const grid            = document.getElementById("album-grid");
@@ -28,6 +30,9 @@ const mbidReleaseInfo = document.getElementById("mbid-release-info");
 const currentMbid     = document.getElementById("current-mbid");
 const lightbox        = document.getElementById("lightbox");
 const lightboxImg     = document.getElementById("lightbox-img");
+const lightboxPrev    = document.getElementById("lightbox-prev");
+const lightboxNext    = document.getElementById("lightbox-next");
+const lightboxCounter = document.getElementById("lightbox-counter");
 const confirmModal    = document.getElementById("confirm-modal");
 const confirmMessage  = document.getElementById("confirm-message");
 const confirmCancel   = document.getElementById("confirm-cancel");
@@ -564,6 +569,10 @@ document.addEventListener("keydown", (e) => {
     if (!lightbox.classList.contains("hidden")) closeLightbox();
     else closeDrawer();
   }
+  if (!lightbox.classList.contains("hidden")) {
+    if (e.key === "ArrowLeft")  navigateLightbox(-1);
+    if (e.key === "ArrowRight") navigateLightbox(1);
+  }
 });
 
 sourcesList.addEventListener("click", (e) => {
@@ -613,21 +622,48 @@ rescanBtn.addEventListener("click", async () => {
 });
 
 /* ── Lightbox ─────────────────────────────────────────────────── */
-function openLightbox(url) {
+function openLightbox(url, items = [], index = -1) {
+  lightboxItems = items;
+  lightboxIndex = index;
   lightboxImg.src = url;
+
+  const hasNav = items.length > 1;
+  lightboxPrev.classList.toggle("hidden", !hasNav);
+  lightboxNext.classList.toggle("hidden", !hasNav);
+  if (hasNav) {
+    lightboxCounter.textContent = `${index + 1} / ${items.length}`;
+    lightboxCounter.classList.remove("hidden");
+  } else {
+    lightboxCounter.classList.add("hidden");
+  }
+
   lightbox.classList.remove("hidden");
+}
+
+function navigateLightbox(dir) {
+  if (!lightboxItems.length) return;
+  lightboxIndex = (lightboxIndex + dir + lightboxItems.length) % lightboxItems.length;
+  lightboxImg.src = lightboxItems[lightboxIndex];
+  lightboxCounter.textContent = `${lightboxIndex + 1} / ${lightboxItems.length}`;
 }
 
 function closeLightbox() {
   lightbox.classList.add("hidden");
   lightboxImg.src = "";
+  lightboxItems = [];
+  lightboxIndex = -1;
 }
 
 currentCover.addEventListener("click", () => {
   if (!currentCover.classList.contains("hidden")) openLightbox(currentCover.src);
 });
 
-lightbox.addEventListener("click", closeLightbox);
+lightbox.addEventListener("click", (e) => {
+  if (!e.target.closest(".lightbox-nav")) closeLightbox();
+});
+
+lightboxPrev.addEventListener("click", (e) => { e.stopPropagation(); navigateLightbox(-1); });
+lightboxNext.addEventListener("click", (e) => { e.stopPropagation(); navigateLightbox(1); });
 
 mediaList.addEventListener("click", (e) => {
   const useBtn = e.target.closest(".use-btn");
@@ -641,12 +677,21 @@ mediaList.addEventListener("click", (e) => {
     return;
   }
   const img = e.target.closest(".media-file img");
-  if (img) openLightbox(img.src);
+  if (img) {
+    const imgs = [...mediaList.querySelectorAll(".media-file img")];
+    const index = imgs.indexOf(img);
+    openLightbox(img.src, imgs.map(i => i.src), index);
+  }
 });
 
 sourcesList.addEventListener("click", (e) => {
   const img = e.target.closest(".source-image img");
-  if (img) openLightbox(img.dataset.fullurl);
+  if (img) {
+    const group = img.closest(".source-group");
+    const imgs = group ? [...group.querySelectorAll(".source-image img")] : [img];
+    const index = imgs.indexOf(img);
+    openLightbox(img.dataset.fullurl, imgs.map(i => i.dataset.fullurl), index);
+  }
 });
 
 /* ── Init ─────────────────────────────────────────────────────── */

--- a/static/index.html
+++ b/static/index.html
@@ -77,7 +77,10 @@
   </div>
 
   <div id="lightbox" class="hidden">
+    <button id="lightbox-prev" class="lightbox-nav hidden" aria-label="Previous">&#8249;</button>
     <img id="lightbox-img" alt="Full size preview">
+    <button id="lightbox-next" class="lightbox-nav hidden" aria-label="Next">&#8250;</button>
+    <span id="lightbox-counter" class="hidden"></span>
   </div>
 
   <script src="/static/app.js"></script>

--- a/static/style.css
+++ b/static/style.css
@@ -675,6 +675,40 @@ body.drawer-open #album-grid { padding-right: calc(var(--drawer-w) + 24px); }
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.8);
 }
 
+.lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 2.5rem;
+  line-height: 1;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+  z-index: 1;
+}
+
+.lightbox-nav:hover { background: rgba(255, 255, 255, 0.18); }
+#lightbox-prev { left: 24px; }
+#lightbox-next { right: 24px; }
+
+#lightbox-counter {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  pointer-events: none;
+}
+
 .current-cover-wrap img { cursor: zoom-in; }
 .media-file img          { cursor: zoom-in; }
 .source-image img        { cursor: zoom-in; }


### PR DESCRIPTION
## Summary

- Lightbox now supports sequential navigation for media assets and source provider image groups
- **Prev/Next buttons** appear on the left/right sides when multiple images are available
- **Left/Right arrow keys** navigate when the lightbox is open
- **Position counter** (e.g. `2 / 5`) shown at the bottom during navigation
- Navigation is context-scoped:
  - **Media assets** → navigates the full media list
  - **Source images** → navigates within each provider's group (CAA, iTunes, Discogs separately)
  - **Current cover** → single image, no nav chrome shown
- Clicking a nav button no longer closes the lightbox; clicking the backdrop still closes it

## Test plan

- [ ] Click a media asset image → lightbox opens with prev/next buttons and counter visible
- [ ] Arrow keys and nav buttons traverse all media assets in order
- [ ] Click a source image (e.g. iTunes) → nav is scoped to that provider's results only
- [ ] Counter updates correctly as you navigate
- [ ] Click the current cover → lightbox opens with no nav buttons or counter
- [ ] Escape closes the lightbox; clicking the backdrop closes it; clicking a nav button does not
- [ ] Navigate to first item and press left → wraps to last; navigate to last and press right → wraps to first