### PR TITLE
fix: search by artist name and debounce input

### DIFF
--- a/server.py
+++ b/server.py
@@ -116,10 +116,14 @@ def scan_library(root: Path) -> dict[str, dict]:
                 pass
         cover_path = _find_cover(path)
         info = _cover_info(cover_path)
+        artist, _ = _parse_artist_album(path.name)
+        if not artist and path.parent != root:
+            artist = path.parent.name
         result[aid] = {
             "id": aid,
             "path": path,
             "name": path.name,
+            "artist": artist,
             "mbid": mbid,
             "cover_path": cover_path,
             **info,
@@ -474,6 +478,7 @@ def api_albums():
             album_list.append({
                 "id": a["id"],
                 "name": a["name"],
+                "artist": a["artist"],
                 "mbid": a["mbid"],
                 "has_cover": a["has_cover"],
                 "cover_size_kb": a["cover_size_kb"],

--- a/static/app.js
+++ b/static/app.js
@@ -81,7 +81,7 @@ function renderGrid() {
   const filter = filterSelect.value;
 
   const filtered = allAlbums.filter(a => {
-    if (query && !a.name.toLowerCase().includes(query)) return false;
+    if (query && !a.name.toLowerCase().includes(query) && !a.artist.toLowerCase().includes(query)) return false;
     if (filter === "low")     return a.has_cover && a.cover_size_kb < 500;
     if (filter === "medium")  return a.has_cover && a.cover_size_kb >= 500 && a.cover_size_kb < 1024;
     if (filter === "high")    return a.has_cover && a.cover_size_kb >= 1024;
@@ -587,7 +587,11 @@ sourcesList.addEventListener("click", (e) => {
   }
 });
 
-searchInput.addEventListener("input", renderGrid);
+let _searchTimer = null;
+searchInput.addEventListener("input", () => {
+  clearTimeout(_searchTimer);
+  _searchTimer = setTimeout(renderGrid, 200);
+});
 filterSelect.addEventListener("change", renderGrid);
 
 const _UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
## Summary

- Artist name is now resolved at scan time and included in the album index
  - For `Artist - Album` folder names, the artist is parsed from the folder name
  - For `Artist/Album/tracks` libraries (the common case), the parent directory name is used as the artist fallback
- Search filter now matches against both the folder name and the resolved artist field
- 200ms debounce added to the search input to avoid re-rendering on every keystroke

## Test plan

- [ ] Rescan or restart the server after pulling
- [ ] Search for an artist name (e.g. "Radiohead") → albums by that artist appear regardless of folder naming convention
- [ ] Search for a partial album name → still works as before
- [ ] Type quickly into the search box → grid only updates after typing pauses (debounce working)
- [ ] Albums in `Artist - Album` flat folders and `Artist/Album` nested folders both match on artist