### PR TITLE
feat: add MusicBrainz alternate versions dropdown to drawer

### DIFF
--- a/server.py
+++ b/server.py
@@ -116,14 +116,17 @@ def scan_library(root: Path) -> dict[str, dict]:
                 pass
         cover_path = _find_cover(path)
         info = _cover_info(cover_path)
-        artist, _ = _parse_artist_album(path.name)
+        artist, album_name = _parse_artist_album(path.name)
         if not artist and path.parent != root:
             artist = path.parent.name
+        if not album_name:
+            album_name = path.name
         result[aid] = {
             "id": aid,
             "path": path,
             "name": path.name,
             "artist": artist,
+            "album_name": album_name,
             "mbid": mbid,
             "cover_path": cover_path,
             **info,
@@ -479,6 +482,7 @@ def api_albums():
                 "id": a["id"],
                 "name": a["name"],
                 "artist": a["artist"],
+                "album_name": a["album_name"],
                 "mbid": a["mbid"],
                 "has_cover": a["has_cover"],
                 "cover_size_kb": a["cover_size_kb"],
@@ -804,6 +808,69 @@ def api_album_use_media(album_id):
         "cover_width": w,
         "cover_height": h,
     })
+
+
+@app.route("/api/albums/<album_id>/mb-releases")
+def api_mb_releases(album_id):
+    """Search MusicBrainz for releases matching this album's artist and title."""
+    with _albums_lock:
+        album = albums.get(album_id)
+    if not album:
+        abort(404)
+
+    artist = album.get("artist", "")
+    album_name = album.get("album_name", "") or album["name"]
+
+    if not artist and not album_name:
+        return jsonify({"releases": []})
+
+    parts = []
+    if album_name:
+        parts.append(f'release:"{album_name}"')
+    if artist:
+        parts.append(f'artistname:"{artist}"')
+    query = " AND ".join(parts)
+
+    url = (
+        f"https://musicbrainz.org/ws/2/release"
+        f"?query={urllib.parse.quote(query)}&fmt=json&limit=12"
+    )
+    def _do_search():
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+
+    try:
+        data = _rate_limited_mb(_do_search)
+    except Exception:
+        return jsonify({"releases": []})
+
+    releases = []
+    for r in data.get("releases", []):
+        artist_credit = "".join(
+            (ac.get("name") or ac.get("artist", {}).get("name", "")) + ac.get("joinphrase", "")
+            for ac in r.get("artist-credit", [])
+            if isinstance(ac, dict)
+        ).strip()
+        label_infos = r.get("label-info", [])
+        label = ""
+        if label_infos and isinstance(label_infos[0], dict):
+            lbl = label_infos[0].get("label")
+            if lbl:
+                label = lbl.get("name", "")
+        release_group = r.get("release-group") or {}
+        releases.append({
+            "id": r["id"],
+            "title": r.get("title", ""),
+            "artist": artist_credit,
+            "date": (r.get("date") or "")[:4],
+            "country": r.get("country", ""),
+            "label": label,
+            "type": release_group.get("primary-type", ""),
+            "score": r.get("score", 0),
+        })
+
+    return jsonify({"releases": releases})
 
 
 @app.route("/api/rescan", methods=["POST"])

--- a/static/app.js
+++ b/static/app.js
@@ -24,9 +24,11 @@ const albumCount      = document.getElementById("album-count");
 const mediaList       = document.getElementById("media-list");
 const noMediaMsg      = document.getElementById("no-media-msg");
 const mediaCount      = document.getElementById("media-count");
-const mbidInput       = document.getElementById("mbid-input");
-const mbidSearchBtn   = document.getElementById("mbid-search-btn");
-const mbidReleaseInfo = document.getElementById("mbid-release-info");
+const mbidInput         = document.getElementById("mbid-input");
+const mbidSearchBtn     = document.getElementById("mbid-search-btn");
+const mbidReleaseInfo   = document.getElementById("mbid-release-info");
+const mbReleasesWrap    = document.getElementById("mb-releases-wrap");
+const mbReleasesSelect  = document.getElementById("mb-releases-select");
 const currentMbid     = document.getElementById("current-mbid");
 const lightbox        = document.getElementById("lightbox");
 const lightboxImg     = document.getElementById("lightbox-img");
@@ -165,6 +167,10 @@ function openDrawer(albumId) {
     currentMbid.className = "mbid-missing";
   }
 
+  // Reset MB releases dropdown
+  mbReleasesWrap.classList.add("hidden");
+  mbReleasesSelect.innerHTML = '<option value="">— select a version —</option>';
+
   // Pre-fill MBID search with tag value if available
   mbidInput.value = album.mbid || "";
   mbidInput.setCustomValidity("");
@@ -186,8 +192,9 @@ function openDrawer(albumId) {
   overlay.classList.add("visible");
   document.body.classList.add("drawer-open");
 
-  // Fetch sources and media async
+  // Fetch sources, releases, and media async
   loadSources(albumId);
+  loadMbReleases(albumId);
   loadMedia(albumId);
 }
 
@@ -248,6 +255,30 @@ function renderReleaseInfo(release) {
   const parts = [release.artist, release.album, release.year, release.label].filter(Boolean);
   mbidReleaseInfo.textContent = parts.join(" \u00b7 ");
   mbidReleaseInfo.classList.remove("hidden");
+}
+
+async function loadMbReleases(albumId) {
+  mbReleasesWrap.classList.add("hidden");
+  mbReleasesSelect.innerHTML = '<option value="">Loading versions...</option>';
+
+  try {
+    const resp = await fetch(`/api/albums/${albumId}/mb-releases`);
+    const data = await resp.json();
+    const releases = data.releases || [];
+
+    mbReleasesSelect.innerHTML = '<option value="">— select a version —</option>';
+    for (const r of releases) {
+      const parts = [r.title, r.artist, r.type, r.date, r.country, r.label].filter(Boolean);
+      const opt = document.createElement("option");
+      opt.value = r.id;
+      opt.textContent = parts.join(" · ");
+      mbReleasesSelect.appendChild(opt);
+    }
+
+    if (releases.length > 0) mbReleasesWrap.classList.remove("hidden");
+  } catch (e) {
+    // silently hide if fetch fails
+  }
 }
 
 async function loadSources(albumId) {
@@ -608,6 +639,14 @@ function triggerMbidSearch() {
 }
 
 mbidSearchBtn.addEventListener("click", triggerMbidSearch);
+
+mbReleasesSelect.addEventListener("change", () => {
+  const mbid = mbReleasesSelect.value;
+  if (!mbid) return;
+  mbidInput.value = mbid;
+  mbidInput.setCustomValidity("");
+  loadSourcesByMbid(activeAlbumId, mbid);
+});
 mbidInput.addEventListener("keydown", (e) => {
   if (e.key === "Enter") triggerMbidSearch();
 });

--- a/static/index.html
+++ b/static/index.html
@@ -52,6 +52,11 @@
 
     <div id="drawer-sources">
       <h3>Find Higher Resolution</h3>
+      <div id="mb-releases-wrap" class="hidden">
+        <select id="mb-releases-select">
+          <option value="">— select a version —</option>
+        </select>
+      </div>
       <div id="mbid-search">
         <input type="text" id="mbid-input" placeholder="Search by Release MBID (UUID)..." autocomplete="off" spellcheck="false">
         <button id="mbid-search-btn">Search</button>

--- a/static/style.css
+++ b/static/style.css
@@ -473,6 +473,26 @@ body.drawer-open #album-grid { padding-right: calc(var(--drawer-w) + 24px); }
   vertical-align: middle;
 }
 
+/* ── MB releases dropdown ─────────────────────────────────────── */
+#mb-releases-wrap {
+  margin-bottom: 10px;
+}
+
+#mb-releases-select {
+  width: 100%;
+  padding: 7px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  outline: none;
+}
+
+#mb-releases-select:focus { border-color: var(--accent); }
+#mb-releases-select option { background: var(--bg-drawer); }
+
 /* ── MBID search ──────────────────────────────────────────────── */
 #mbid-search {
   display: flex;


### PR DESCRIPTION
## Summary

- A dropdown appears above the MBID search input listing alternate releases found on MusicBrainz for the current album's artist and title
- Each option shows: `Title · Artist · Type · Year · Country · Label`
- Selecting an entry immediately populates the MBID input and triggers an art search for that release — no button press required
- The dropdown is hidden when no MB results are found (no visual noise for unrecognised albums)
- New backend endpoint: `GET /api/albums/<id>/mb-releases` — rate-limited MusicBrainz release search, returns up to 12 results
- `album_name` is now stored as a separate parsed field in the scan index (used by the search and by this endpoint)

## Test plan

- [ ] Open a well-known album drawer → dropdown appears with alternate versions after a short MB lookup
- [ ] Select a version from the dropdown → MBID input updates and art sources reload for that release
- [ ] Open an album that MB can't match → dropdown stays hidden
- [ ] Manual MBID entry and Search button still work independently
- [ ] Rescan after pulling to repopulate `album_name` in the index