### PR TITLE
refactor: remove global init() from sources.py (#22)

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,7 +30,6 @@ from fetch_cover_art import (
 from library import _album_id, _find_cover, _cover_info, _parse_artist_album, scan_library
 from probing import _detect_duplicates
 from sources import fetch_sources, _search_itunes, _search_discogs, _search_caa
-import sources as _sources_mod
 
 app = Flask(__name__, static_folder="static", static_url_path="/static")
 
@@ -64,9 +63,6 @@ def _rate_limited_mb(fn, *args, **kwargs):
     return fn(*args, **kwargs)
 
 
-_sources_mod.init(_rate_limited_mb)
-
-
 def _save_thumbnail(img: Image.Image, album_dir: Path, ext: str) -> None:
     try:
         thumb = img.copy()
@@ -78,6 +74,7 @@ def _save_thumbnail(img: Image.Image, album_dir: Path, ext: str) -> None:
             thumb.save(thumb_path)
     except Exception:
         pass
+
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +127,7 @@ def api_album_sources(album_id):
         album = albums.get(album_id)
     if not album:
         abort(404)
-    sources = fetch_sources(album)
+    sources = fetch_sources(album, rate_limited_mb=_rate_limited_mb)
     return jsonify({"sources": sources})
 
 
@@ -150,7 +147,7 @@ def api_mbid_sources(mbid):
         "cover_width": 0,
         "cover_height": 0,
     }
-    sources = fetch_sources(synthetic_album, artist=release["artist"], album_name=release["album"])
+    sources = fetch_sources(synthetic_album, artist=release["artist"], album_name=release["album"], rate_limited_mb=_rate_limited_mb)
     return jsonify({"sources": sources, "release": release})
 
 

--- a/sources.py
+++ b/sources.py
@@ -17,21 +17,12 @@ from probing import _detect_duplicates, _probe_images_batch
 
 DISCOGS_TOKEN: str | None = os.environ.get("DISCOGS_TOKEN")
 
-_rate_limited_mb = None
-
-
-def init(rate_limited_mb_fn):
-    global _rate_limited_mb
-    _rate_limited_mb = rate_limited_mb_fn
-
-
-def _search_caa(mbid: str) -> dict:
-    """Search Cover Art Archive for all images."""
+def _search_caa(mbid: str, rate_limited_mb) -> dict:
     source = {"source": "Cover Art Archive", "images": []}
     if not mbid:
         return source
     try:
-        listing = _rate_limited_mb(fetch_cover_art_listing, mbid)
+        listing = rate_limited_mb(fetch_cover_art_listing, mbid)
     except FetchError:
         return source
     for img in listing.get("images", []):
@@ -127,14 +118,13 @@ def _search_discogs(artist: str, album: str) -> dict:
     return source
 
 
-def fetch_sources(album: dict, *, artist: str = "", album_name: str = "") -> list[dict]:
-    """Query all sources in parallel, probe images, and detect duplicates."""
+def fetch_sources(album: dict, *, artist: str = "", album_name: str = "", rate_limited_mb) -> list[dict]:
     mbid = album.get("mbid")
 
     if not artist and not album_name:
         if mbid:
             try:
-                artist, album_name = _rate_limited_mb(fetch_release_info, mbid)
+                artist, album_name = rate_limited_mb(fetch_release_info, mbid)
             except FetchError:
                 pass
 
@@ -144,7 +134,7 @@ def fetch_sources(album: dict, *, artist: str = "", album_name: str = "") -> lis
     sources = []
     with ThreadPoolExecutor(max_workers=3) as pool:
         futures = {
-            pool.submit(_search_caa, mbid): "caa",
+            pool.submit(_search_caa, mbid, rate_limited_mb): "caa",
             pool.submit(_search_itunes, artist, album_name): "itunes",
             pool.submit(_search_discogs, artist, album_name): "discogs",
         }


### PR DESCRIPTION
## Summary
- Removes `_rate_limited_mb` module-level global and `init()` function from `sources.py`
- Adds `rate_limited_mb` as an explicit keyword parameter to `fetch_sources()` and threads it through to `_search_caa()`
- Updates the two `fetch_sources()` call sites in `server.py` to pass `rate_limited_mb=_rate_limited_mb`

Fixes #22.