### PR TITLE
refactor: remove misleading underscore prefixes from public functions (#23)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ from PIL import Image
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import server
-from library import _album_id, _cover_info
+from library import album_id, cover_info
 
 
 def make_png_header(width, height):
@@ -66,8 +66,8 @@ def populated_client(client, tmp_path):
     Image.new("RGB", (600, 600), color="blue").save(buf, format="JPEG")
     cover.write_bytes(buf.getvalue())
 
-    aid = _album_id(album_dir)
-    info = _cover_info(cover)
+    aid = album_id(album_dir)
+    info = cover_info(cover)
     server.albums[aid] = {
         "id": aid,
         "path": album_dir,

--- a/library.py
+++ b/library.py
@@ -10,11 +10,11 @@ from PIL import Image
 from fetch_cover_art import MUSIC_EXTENSIONS, first_music_file, read_mbid_from_file
 
 
-def _album_id(path: Path) -> str:
+def album_id(path: Path) -> str:
     return hashlib.md5(str(path).encode()).hexdigest()[:12]
 
 
-def _find_cover(album_dir: Path) -> Path | None:
+def find_cover(album_dir: Path) -> Path | None:
     for ext in (".jpg", ".jpeg", ".png", ".webp", ".gif"):
         p = album_dir / f"cover{ext}"
         if p.exists():
@@ -22,7 +22,7 @@ def _find_cover(album_dir: Path) -> Path | None:
     return None
 
 
-def _cover_info(cover_path: Path | None) -> dict:
+def cover_info(cover_path: Path | None) -> dict:
     if cover_path is None or not cover_path.exists():
         return {"has_cover": False, "cover_size_kb": 0, "cover_width": 0, "cover_height": 0}
     size_kb = round(cover_path.stat().st_size / 1024, 1)
@@ -34,7 +34,7 @@ def _cover_info(cover_path: Path | None) -> dict:
     return {"has_cover": True, "cover_size_kb": size_kb, "cover_width": w, "cover_height": h}
 
 
-def _parse_artist_album(dirname: str) -> tuple[str, str]:
+def parse_artist_album(dirname: str) -> tuple[str, str]:
     """Best-effort parse 'Artist - Album' or 'Artist - Album [mbid]' from folder name."""
     name = re.sub(r"\s*\[[\da-f-]{36}\]\s*$", "", dirname)
     if " - " in name:
@@ -50,7 +50,7 @@ def scan_library(root: Path) -> dict[str, dict]:
         path = Path(dirpath)
         if not any(Path(f).suffix.lower() in MUSIC_EXTENSIONS for f in filenames):
             continue
-        aid = _album_id(path)
+        aid = album_id(path)
         music_file = first_music_file(path)
         mbid = None
         if music_file:
@@ -58,9 +58,9 @@ def scan_library(root: Path) -> dict[str, dict]:
                 mbid = read_mbid_from_file(music_file)
             except Exception:
                 pass
-        cover_path = _find_cover(path)
-        info = _cover_info(cover_path)
-        artist, album_name = _parse_artist_album(path.name)
+        cover_path = find_cover(path)
+        info = cover_info(cover_path)
+        artist, album_name = parse_artist_album(path.name)
         if not artist and path.parent != root:
             artist = path.parent.name
         if not album_name:

--- a/probing.py
+++ b/probing.py
@@ -97,7 +97,7 @@ def _probe_image(url: str) -> dict:
     return result
 
 
-def _probe_images_batch(images: list[dict]) -> list[dict]:
+def probe_images_batch(images: list[dict]) -> list[dict]:
     """Probe a batch of images in parallel, adding size_kb/width/height to each."""
     def probe_one(img):
         if "itunes.apple.com" in img.get("url", ""):
@@ -129,8 +129,8 @@ def _probe_images_batch(images: list[dict]) -> list[dict]:
     return images
 
 
-def _detect_duplicates(images: list[dict], current_size_kb: float,
-                       current_w: int, current_h: int) -> list[dict]:
+def detect_duplicates(images: list[dict], current_size_kb: float,
+                      current_w: int, current_h: int) -> list[dict]:
     """Mark images that are likely the same as the current cover.
 
     Adds a "match" field: "current" if likely the same image, else None.

--- a/server.py
+++ b/server.py
@@ -27,9 +27,9 @@ from fetch_cover_art import (
     USER_AGENT,
     FetchError,
 )
-from library import _album_id, _find_cover, _cover_info, _parse_artist_album, scan_library
-from probing import _detect_duplicates
-from sources import fetch_sources, _search_itunes, _search_discogs, _search_caa
+from library import album_id, find_cover, cover_info, parse_artist_album, scan_library
+from probing import detect_duplicates
+from sources import fetch_sources, search_itunes, search_discogs, search_caa
 
 app = Flask(__name__, static_folder="static", static_url_path="/static")
 
@@ -361,7 +361,7 @@ def api_album_use_media(album_id):
     except Exception:
         return jsonify({"error": "File is not a valid image"}), 400
 
-    current_cover = _find_cover(album_dir)
+    current_cover = find_cover(album_dir)
     if current_cover:
         media_dir.mkdir(exist_ok=True)
         cover_ext = current_cover.suffix

--- a/sources.py
+++ b/sources.py
@@ -12,12 +12,12 @@ from fetch_cover_art import (
     fetch_cover_art_listing,
     fetch_release_info,
 )
-from library import _parse_artist_album
-from probing import _detect_duplicates, _probe_images_batch
+from library import parse_artist_album
+from probing import detect_duplicates, probe_images_batch
 
 DISCOGS_TOKEN: str | None = os.environ.get("DISCOGS_TOKEN")
 
-def _search_caa(mbid: str, rate_limited_mb) -> dict:
+def search_caa(mbid: str, rate_limited_mb) -> dict:
     source = {"source": "Cover Art Archive", "images": []}
     if not mbid:
         return source
@@ -45,7 +45,7 @@ def _search_caa(mbid: str, rate_limited_mb) -> dict:
     return source
 
 
-def _search_itunes(artist: str, album: str) -> dict:
+def search_itunes(artist: str, album: str) -> dict:
     """Search iTunes for album artwork."""
     source = {"source": "iTunes", "images": []}
     if not artist and not album:
@@ -78,7 +78,7 @@ def _search_itunes(artist: str, album: str) -> dict:
     return source
 
 
-def _search_discogs(artist: str, album: str) -> dict:
+def search_discogs(artist: str, album: str) -> dict:
     """Search Discogs for cover images. Requires DISCOGS_TOKEN."""
     source = {"source": "Discogs", "images": []}
     if not DISCOGS_TOKEN:
@@ -129,14 +129,14 @@ def fetch_sources(album: dict, *, artist: str = "", album_name: str = "", rate_l
                 pass
 
         if not artist and not album_name:
-            artist, album_name = _parse_artist_album(album["name"])
+            artist, album_name = parse_artist_album(album["name"])
 
     sources = []
     with ThreadPoolExecutor(max_workers=3) as pool:
         futures = {
-            pool.submit(_search_caa, mbid, rate_limited_mb): "caa",
-            pool.submit(_search_itunes, artist, album_name): "itunes",
-            pool.submit(_search_discogs, artist, album_name): "discogs",
+            pool.submit(search_caa, mbid, rate_limited_mb): "caa",
+            pool.submit(search_itunes, artist, album_name): "itunes",
+            pool.submit(search_discogs, artist, album_name): "discogs",
         }
         for future in as_completed(futures):
             try:
@@ -148,9 +148,9 @@ def fetch_sources(album: dict, *, artist: str = "", album_name: str = "", rate_l
 
     all_images = [img for src in sources for img in src["images"]]
     if all_images:
-        _probe_images_batch(all_images)
+        probe_images_batch(all_images)
 
-        _detect_duplicates(
+        detect_duplicates(
             all_images,
             album.get("cover_size_kb", 0),
             album.get("cover_width", 0),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -14,7 +14,7 @@ from fetch_cover_art import (
     lookup_acoustid,
     post,
 )
-from sources import _search_itunes
+from sources import search_itunes
 
 
 def _mock_urlopen_response(data: bytes, status=200):
@@ -237,7 +237,7 @@ class TestLookupAcoustid:
         assert lookup_acoustid("key", 180, "fp") == []
 
 
-# ── _search_itunes() ────────────────────────────────────────────
+# ── search_itunes() ────────────────────────────────────────────
 
 
 class TestSearchItunes:
@@ -250,7 +250,7 @@ class TestSearchItunes:
                 "artistName": "Pink Floyd",
             }]
         }).encode())
-        result = _search_itunes("Pink Floyd", "DSOTM")
+        result = search_itunes("Pink Floyd", "DSOTM")
         assert result["source"] == "iTunes"
         assert len(result["images"]) == 3
         urls = [img["url"] for img in result["images"]]
@@ -263,15 +263,15 @@ class TestSearchItunes:
         mock_urlopen.return_value = _mock_urlopen_response(json.dumps({
             "results": [{"collectionName": "X", "artistName": "Y"}]
         }).encode())
-        result = _search_itunes("Y", "X")
+        result = search_itunes("Y", "X")
         assert result["images"] == []
 
     @patch("urllib.request.urlopen")
     def test_network_error_returns_empty(self, mock_urlopen):
         mock_urlopen.side_effect = Exception("timeout")
-        result = _search_itunes("Pink Floyd", "DSOTM")
+        result = search_itunes("Pink Floyd", "DSOTM")
         assert result == {"source": "iTunes", "images": []}
 
     def test_empty_query_returns_empty(self):
-        result = _search_itunes("", "")
+        result = search_itunes("", "")
         assert result == {"source": "iTunes", "images": []}

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 from fetch_cover_art import ext_from_url, safe_dirname, build_output_dir
-from library import _parse_artist_album, _album_id
-from probing import _detect_duplicates
+from library import parse_artist_album, album_id
+from probing import detect_duplicates
 
 
 # --- ext_from_url ---
@@ -84,62 +84,62 @@ def test_build_output_dir_special_chars_sanitized():
     assert result == Path("AC_DC - Who Made Who_ [abc-123]")
 
 
-# --- _parse_artist_album ---
+# --- parse_artist_album ---
 
 def test_parse_artist_album_standard():
-    assert _parse_artist_album("Pink Floyd - DSOTM") == ("Pink Floyd", "DSOTM")
+    assert parse_artist_album("Pink Floyd - DSOTM") == ("Pink Floyd", "DSOTM")
 
 
 def test_parse_artist_album_strips_mbid_suffix():
-    assert _parse_artist_album(
+    assert parse_artist_album(
         "Pink Floyd - DSOTM [76df3287-6cda-33eb-8e9a-044b5e15ffdd]"
     ) == ("Pink Floyd", "DSOTM")
 
 
 def test_parse_artist_album_no_separator():
-    assert _parse_artist_album("JustAnAlbum") == ("", "JustAnAlbum")
+    assert parse_artist_album("JustAnAlbum") == ("", "JustAnAlbum")
 
 
 def test_parse_artist_album_multiple_dashes_splits_on_first():
-    assert _parse_artist_album("A - B - C") == ("A", "B - C")
+    assert parse_artist_album("A - B - C") == ("A", "B - C")
 
 
 def test_parse_artist_album_whitespace_handling():
-    assert _parse_artist_album("  Artist  -  Album  ") == ("Artist", "Album")
+    assert parse_artist_album("  Artist  -  Album  ") == ("Artist", "Album")
 
 
 def test_parse_artist_album_non_uuid_brackets_preserved():
-    assert _parse_artist_album("Artist - Album [Deluxe]") == ("Artist", "Album [Deluxe]")
+    assert parse_artist_album("Artist - Album [Deluxe]") == ("Artist", "Album [Deluxe]")
 
 
-# --- _album_id ---
+# --- album_id ---
 
 def test_album_id_deterministic():
     p = Path("/music/Pink Floyd - DSOTM")
-    assert _album_id(p) == _album_id(p)
+    assert album_id(p) == album_id(p)
 
 
 def test_album_id_different_paths_differ():
-    assert _album_id(Path("/a")) != _album_id(Path("/b"))
+    assert album_id(Path("/a")) != album_id(Path("/b"))
 
 
-# --- _detect_duplicates ---
+# --- detect_duplicates ---
 
 def test_detect_duplicates_exact_size_match():
     images = [{"size_kb": 100.5, "width": 800, "height": 800}]
-    result = _detect_duplicates(images, current_size_kb=101.0, current_w=600, current_h=600)
+    result = detect_duplicates(images, current_size_kb=101.0, current_w=600, current_h=600)
     assert result[0]["match"] == "current"
 
 
 def test_detect_duplicates_resolution_and_size_match():
     images = [{"size_kb": 110.0, "width": 600, "height": 600}]
-    result = _detect_duplicates(images, current_size_kb=100.0, current_w=600, current_h=600)
+    result = detect_duplicates(images, current_size_kb=100.0, current_w=600, current_h=600)
     assert result[0]["match"] == "current"
 
 
 def test_detect_duplicates_no_match_when_too_different():
     images = [{"size_kb": 200.0, "width": 800, "height": 800}]
-    result = _detect_duplicates(images, current_size_kb=100.0, current_w=600, current_h=600)
+    result = detect_duplicates(images, current_size_kb=100.0, current_w=600, current_h=600)
     assert result[0]["match"] is None
 
 
@@ -148,11 +148,11 @@ def test_detect_duplicates_skips_all_when_no_current_cover():
         {"size_kb": 100.0, "width": 600, "height": 600},
         {"size_kb": 200.0, "width": 800, "height": 800},
     ]
-    result = _detect_duplicates(images, current_size_kb=0, current_w=0, current_h=0)
+    result = detect_duplicates(images, current_size_kb=0, current_w=0, current_h=0)
     assert all(img["match"] is None for img in result)
 
 
 def test_detect_duplicates_size_match_takes_priority():
     images = [{"size_kb": 100.0, "width": 600, "height": 600}]
-    result = _detect_duplicates(images, current_size_kb=100.5, current_w=600, current_h=600)
+    result = detect_duplicates(images, current_size_kb=100.5, current_w=600, current_h=600)
     assert result[0]["match"] == "current"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,7 +40,7 @@ def test_albums_sorted_case_insensitive(client, tmp_path):
     for name in ["Zeppelin - II", "abba - Gold", "Beatles - Abbey"]:
         d = tmp_path / name
         d.mkdir()
-        aid = server._album_id(d)
+        aid = server.album_id(d)
         server.albums[aid] = {
             "id": aid,
             "path": d,
@@ -89,7 +89,7 @@ def test_album_cover_unknown_album(client):
 def test_album_cover_no_cover_path(client, tmp_path):
     d = tmp_path / "empty-album"
     d.mkdir()
-    aid = server._album_id(d)
+    aid = server.album_id(d)
     server.albums[aid] = {
         "id": aid,
         "path": d,


### PR DESCRIPTION
Rename functions that have underscore prefixes but are imported and used across module boundaries, fixing GitHub issue #23.

## Changes

- **library.py**: `_album_id` → `album_id`, `_find_cover` → `find_cover`, `_cover_info` → `cover_info`, `_parse_artist_album` → `parse_artist_album`
- **probing.py**: `_detect_duplicates` → `detect_duplicates`, `_probe_images_batch` → `probe_images_batch`
- **sources.py**: `_search_caa` → `search_caa`, `_search_itunes` → `search_itunes`, `_search_discogs` → `search_discogs`

Updated all imports and call sites in:
- server.py
- conftest.py
- tests/test_pure.py
- tests/test_http.py
- tests/test_server.py